### PR TITLE
Pipeline Sampling Fix and Kinematics/General Docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,3 +18,19 @@ See [Converting to Dataframes](./user_guide/kinematics/index.md#converting-to-da
 ## How can make attpc_engine output data into a different format
 See **Put detector ref here**
 
+## How do I update my version of attpc_engine
+
+With your virtual environment active you can use any of
+
+```bash
+pip install attpc_engine --upgrade
+pip install attpc_engine -U
+```
+
+or to install a specific version use
+
+```bash
+pip install attpc_engine==x.x.x
+```
+and replace `x.x.x` with the specific version number to install.
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,20 @@
+# Frequently Asked Questions
+
+## How do I install attpc_engine
+See [Setup and Installation](user_guide/setup.md)
+
+## How do I get started using attpc_engine
+See [Getting Started](user_guide/getting_started.md)
+
+## How do I contribute to attpc_engine
+See [For Developers](for_devs.md)
+
+## How do I know if attpc_engine can be used with my dataset
+In general attpc_engine is flexible, and can generate data for many different types of AT-TPC experiments. However, the detector system side of attpc_engine is rather fixed at the moment. Serious modifications to the AT-TPC geometry and behavior may make certain datasets incompatible, as well as attpc_engine is not designed to simulate the behavior of additional detector components. But the kinematics sampler should be valid for most types of reactions with AT-TPC.
+
+## How can I look at the kinematics data without detector effects applied
+See [Converting to Dataframes](./user_guide/kinematics/index.md#converting-to-dataframes)
+
+## How can make attpc_engine output data into a different format
+See **Put detector ref here**
+

--- a/docs/for_devs.md
+++ b/docs/for_devs.md
@@ -1,0 +1,69 @@
+# For Developers
+
+attpc_engine is always looking for input and improvements! If you would like to join in our collaboration, please notify a maintainer of the [AT-TPC GitHub](https://github.com/attpc/) or attpc_engine. They can add you as a collaborator and setup a development branch for you in attpc_engine. New ideas are always welcome! Below are some outlines for working in the attpc_engine collaboration.
+
+## Required Development Tools
+
+### PDM
+
+attpc_engine uses [PDM](https://pdm-project.org/en/latest/) as it's project management tool.
+
+## Pull Requests
+
+### Statement of Intent
+
+Please state in the pull request what the goal of is of this modification to attpc_engine and what was changed to accomplish this. If there is no statement of intent, the pull request will not be accepted.
+
+### Statement of Dependencies
+
+Please state in the pull request what new dependencies (if any) were added and please make sure that these new dependencies were added to the attpc_engine `pyproject.toml` with a version range specified. If the dependencies were not stated, the pull request will not be accepted. Please check to make sure that any new dependencies are compliant with the [GPL3](https://www.gnu.org/licenses/gpl-3.0.en.html) license which is used by attpc_engine.
+
+### Review
+
+Any pull request will require at least one reviewer.
+
+## Code Requirements
+
+Below are some of the requirements for any code added to attpc_engine:
+
+### Docstrings
+
+Please provide docstrings for each function and class. Dataclasses do not necessarily need docstrings. This helps other developers understand what the purpose and usage code. Check out some of the docstrings in attpc_engine to get a feel for the expected format.
+
+### Type Hints
+
+Please use [type hints](https://docs.python.org/3/library/typing.html) to annotate your code where applicable. This includes function arguments, return values, and any variables where the type might be ambiguous. In general, a good rule to follow is: can your IDE determine the type of the variable? If it can it doesn't need a type hint. If it can't, the variable needs a type hint. The Any type hint is allowed in some specific cases. Functions which return None do not need a return type hint.
+
+In some places in the code you may notice the comment `# type: ignore`. The attpc_engine development team uses type checking to help detect and eliminate issues in the codebase before they get deployed. However, many libraries don't provide a level of typing which allows for type checking. This comment will disable type checking and static type analysis for that line. It should only be used when it has been confirmed through testing that that line behaves as expected.
+
+### Formatting
+
+attpc_engine uses the black formatter. The appropriate version of black is included in the pyproject.toml file, so simply install and everything should be good to go.
+
+### Files
+
+Please try to keep files from being monster 1000 lines of code documents. This is not a hard and fast rule, but in general files should contain a unqiue individual unit of code which interfaces with the rest of the framework. There can be execptions.
+
+### Unit Tests
+
+Where reasonable, please provide unit tests in the tests directory for code you add. Obviously, as a simulation library, there are limitations to what tests we can automate without CI taking forever. But they are really helpful for making sure things don't break.
+
+### Documentation
+
+If you decide to contribute a new major feature to attpc_engine, please prepeare some documentation to be added to this site. It should at least outline what new configuration parameters are exposed and what effect this may have upon the data. Documentation should be contributed in the form of Markdown files in the `docs` directory. Our documenation is built using the amazing [MkDocs](https://www.mkdocs.org/) and the [MkDocs-Material](https://squidfunk.github.io/mkdocs-material/) theme.
+
+## Final Thoughts
+
+Below is an example pull request descripton:
+
+```txt
+Intent:
+Fix a bug in configuration parsing in attpc_engine and write to YAML
+
+Dependencies Added:
+pyyaml
+```
+
+Feel free to use this as a simple template if you wish!
+
+If you find that you need to really customize your attpc_engine to fit your specific experiment, please consider forking the parent attpc_engine repository. This will allow you to still get all the power of GitHub and version control, without having to make your code necessarily complaint with attpc_engine's restrictions.

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -1,0 +1,247 @@
+# Getting Started
+
+Once attpc_engine is installed it's time to setup our simulation project. Below is an outline of what we'd expect your project structure to look like
+
+```txt
+|---my_sim
+|   |---generate_kinematics.py
+|   |---apply_detector.py
+|   |---.venv
+|   |---output
+|   |   |---kinematics
+|   |   |---detector
+```
+
+You have a folder (in this case called `my_sim`) with two Python files (`generate_kinematics.py` and `apply_detector.py`) a virtual environment with attpc_engine installed (`.venv`) and an output directory with a folder for kinematics and detector effects. Note that you may want the output to be stored on a remote disk or other location as simulation files can be big at times (> 1 GB).
+
+Now lets talk about generating and sampling a kinematics phase space!
+
+## Sampling Kinematics
+
+Below is an example script for running a kinematics sample, which in our example project we would write in `my_sim/generate_kinematics.py`
+
+```python
+from attpc_engine.kinematics import (
+    KinematicsPipeline,
+    KinematicsTargetMaterial,
+    ExcitationGaussian,
+    run_kinematics_pipeline,
+    Reaction,
+)
+from attpc_engine import nuclear_map
+from spyral_utils.nuclear.target import TargetData, GasTarget
+from pathlib import Path
+
+output_path = Path("./output/kinematics/c16dd_d2_300Torr_184MeV.h5")
+
+target = GasTarget(
+    TargetData(compound=[(1, 2, 2)], pressure=300.0, thickness=None), nuclear_map
+)
+
+nevents = 10000
+
+beam_energy = 184.131 # MeV
+
+pipeline = KinematicsPipeline(
+    [
+        Reaction(
+            target=nuclear_map.get_data(1, 2), # deuteron
+            projectile=nuclear_map.get_data(6, 16), # 16C
+            ejectile=nuclear_map.get_data(1, 2), # deuteron
+        )
+    ],
+    [ExcitationGaussian(0.0, 0.001)], # No width to ground state
+    beam_energy=184.131, # MeV
+    target_material=KinematicsTargetMaterial(
+        material=target, z_range=(0.0, 1.0), rho_sigma=0.007
+    ),
+)
+
+def main():
+    run_kinematics_pipeline(pipeline, nevents, output_path)
+
+if __name__ == "__main__":
+    main()
+```
+
+First we import all of our pieces from the attpc_engine library and its dependencies. We also import the Python standard library Path object to handle our file paths.
+
+We then start to define our kinematics configuration. First we define the output path to be an HDF5 file in our output directory. We also define a spyral-utils [gas target](https://attpc.github.io/spyral-utils/api/nuclear/target) of  $^2H_2$ at 300 Torr pressure.
+
+```python
+target = GasTarget(
+    TargetData(compound=[(1, 2, 2)], pressure=300.0, thickness=None), nuclear_map
+)
+```
+
+We ask for 10000 events to be sampled, and set our beam energy to about 184 MeV.
+
+```python
+nevents = 10000
+
+beam_energy = 184.131 # MeV
+```
+ 
+Now were ready to define our kinematics Pipeline. The first argument of the Pipeline is a list of steps, where each step is either a Reaction or Deacy. The first element of the list must *always* be a Reaction, and all subsequent steps are *always* Decays. The residual of the previous step is *always* the parent of the next step. The Pipeline will attempt to validate this information for you. We also must define a list of ExcitationDistribution objects. These describe the state in the residual that is populated by each Reaction/Decay. There is exactly *one* distribution per step. There are two types of predefined ExcitationDistributions (ExcitationGaussian and ExcitationUniform), but others can be implemented by implementing theExcitationDistribution protocol. We also define our KinematicsTargetMaterial, which includes our gas target, as well as the allowed space within the target for our reaction vertex (range in z in meters and standard deviation of cylindrical &rho; in meters).
+
+```python
+pipeline = KinematicsPipeline(
+    # Define a reaction chain (here just one simple scattering reaction)
+    [
+        Reaction(
+            target=nuclear_map.get_data(1, 2), # deuteron
+            projectile=nuclear_map.get_data(6, 16), # 16C
+            ejectile=nuclear_map.get_data(1, 2), # deuteron
+        )
+    ],
+    # Define our excitations
+    [ExcitationGaussian(0.0, 0.0)], # No width to ground state
+    beam_energy=184.131, # MeV
+    target_material=KinematicsTargetMaterial(
+        material=target, z_range=(0.0, 1.0), rho_sigma=0.007
+    ),
+)
+```
+
+Now we can setup a main function wrapping launching the pipeline
+
+```python
+ def main():
+    run_kinematics_pipeline(pipeline, nevents, output_path)
+```
+
+And finally, we setup the script to call main when run
+
+```python
+if __name__ == "__main__":
+    main()
+```
+
+That's it! This script will then sample 10000 events from the kinematic phase space of ${}^{16}C(d,d')$ and write the data out to an HDF5 file in our output directory.
+
+## Applying the Detector
+
+Below is an example script for running a kinematics sample, which in our example project we would write in `my_sim/apply_detector.py`
+
+```python
+from attpc_engine.detector import (
+    DetectorParams,
+    ElectronicsParams,
+    PadParams,
+    Config,
+    run_simulation,
+    SpyralWriter,
+)
+
+from attpc_engine import nuclear_map
+from spyral_utils.nuclear.target import TargetData, GasTarget
+from pathlib import Path
+
+input_path = "output/kinematics/c16dd_d2_300Torr_184MeV.h5"
+output_path = Path("output/detector/run_0001.h5")
+
+
+gas = GasTarget(TargetData([(1, 2, 2)], pressure=300.0), nuclear_map)
+
+detector = DetectorParams(
+    length=1.0,
+    efield=45000.0,
+    bfield=2.85,
+    mpgd_gain=175000,
+    gas_target=gas,
+    diffusion=0.277,
+    fano_factor=0.2,
+    w_value=34.0,
+)
+
+electronics = ElectronicsParams(
+    clock_freq=6.25,
+    amp_gain=900,
+    shaping_time=1000,
+    micromegas_edge=10,
+    windows_edge=560,
+    adc_threshold=40.0,
+)
+
+pads = PadParams()
+
+config = Config(detector, electronics, pads)
+writer = SpyralWriter(output_path, config)
+
+def main():
+    run_simulation(
+        config,
+        input_path,
+        writer,
+    )
+
+if __name__ == "__main__":
+    main()
+```
+
+Just like in the kinematics script, we start off by importing a whole bunch of code. Next we define our kinematics input (which is the output of the kinematics script) and an output path. Note here we've chosen to make our detector output file name match a format expected by the Spyral analysis framework.
+
+```python
+input_path = "output/kinematics/c16dd_d2_300Torr_184MeV.h5"
+output_path = Path("output/detector/run_0001.h5")
+```
+
+Then we define the same gas target that we used in the kinematics pipeline
+
+```python
+gas = GasTarget(TargetData([(1, 2, 2)], pressure=300.0), nuclear_map)
+```
+
+and finally we begin to define the detector specific configuration, which is ultimately stored in a Config object.
+
+```python
+detector = DetectorParams(
+    length=1.0,
+    efield=45000.0,
+    bfield=2.85,
+    mpgd_gain=175000,
+    gas_target=gas,
+    diffusion=0.277,
+    fano_factor=0.2,
+    w_value=34.0,
+)
+
+electronics = ElectronicsParams(
+    clock_freq=6.25,
+    amp_gain=900,
+    shaping_time=1000,
+    micromegas_edge=10,
+    windows_edge=560,
+    adc_threshold=40.0,
+)
+
+pads = PadParams()
+
+config = Config(detector, electronics, pads)
+```
+
+Note that by not passing any arguments to `PadParams` we are using the default pad description that is bundled with the package. See the [detector](./detector/index.md) guide for more details. For the output, we create a SpyralWriter object. This will take in the simulation data and convert it to match the format expected by the Spyral analysis.
+
+```python
+writer = SpyralWriter(output_path, config)
+```
+
+Then, just like in the kinematics script we set up a main function and set it to be run when the script is processed
+
+```python
+def main():
+    run_simulation(
+        config,
+        input_path,
+        writer,
+    )
+
+if __name__ == "__main__":
+    main()
+```
+
+And just like that, we can now take our kinematic samples and apply detector effects!
+
+## More Details
+
+See the discussion of the systems [here](systems.md)

--- a/docs/user_guide/kinematics/index.md
+++ b/docs/user_guide/kinematics/index.md
@@ -1,0 +1,35 @@
+# Kinematics Sampling
+
+The kinematics system is focused on sampling the phase space allowed by a given reaction configuration. This involves specifying a reaction system and the number of samples needed, as well as the shape of the underlying distributions to be sampled from. Below we'll talk about each of these ideas and cover how to specify them in attpc_engine.
+
+## Reactions
+
+The core underlying model of the kinematics is that of a [reaction](../../api/kinematics/reaction.md). In attpc_engine there are two types of reactions. 
+
+The first is called Reaction, which is of the kind $a(b, c)d$ where you have an incoming projectile (sometimes referred to as the beam) incident upon a target particle. The nuclei react and produce two products, one of which we refer to as an ejectile (this is typically the $c$ in the reaction equation) and the other we refer to as the residual (typically the $d$ in the above equation). In attpc_engine you define a reaction by providing the projectile, target, and ejectile nuclei. The residual is calculated for you based on the other inputs. 
+
+The second is called a Decay, which is of the kind $a \rightarrow b+c$ where the parent nucleus, $a$, decays into two products $b$ and $c$. In attpc_engine you specify a Decay by the parent and one of the decay products. The other product is calculated for you.
+
+Tying these two together is the concept of a reaction chain. Some experiments investigate the following: $a(b,c)d\rightarrow e+f$ where you have a primary reaction resulting in a residual that then undergoes a decay. In attpc_engine you can simulate this by providing a Reaction, followed by a Decay. The residual of the Reaction should then match the parent of the Decay. This will be validated for you at runtime.
+
+In attpc_engine, reaction chains must *always* start with a Reaction, which can *only* be followed by Deacys. However, as long as it is energetically allowed, you can chain as many Decays as you would like.
+
+## Sampling
+
+With a reaction specified, we now need to describe how to sample from the reaction. In particular, there are a few key concepts: the beam (projectile) energy, the reaction angle, the propogation of previous steps, and the excitation of residual nuclei. Each of these plays a role in defining and sampling the phase space.
+
+### The Beam Energy
+
+In AT-TPC experiments, the detector often samples a range of beam energies due to the active target. That is, as the beam travels through the gas, it loses energy until it finally undergoes a reaction. To simulate this effect, you can specify a target material and the range of z-positions over which the reaction can take place (see [here](../../api/kinematics/pipeline.md)). The simulation will then uniformly sample along that z-range and calculate the beam energy for a given z. As an additional effect, you can specify a standard deviation in cylindrical &rho; over which to sample a beam offset (simulate a beam spot) in a normal distribution. The beam is assumed to be uniformly distributed in cylindrical &theta;. Note that the &rho; sampling has no effect on the beam energy. The beam is assumed to be travelling parallel to the beam axis.
+
+### Reaction Angles
+
+With a beam energy specified, the next step is to sample the reaction angles. This means sampling both spherical &theta; and &phi; in the center-of-mass frame of the incoming system (the target + projectile in the case of a Reaction, parent in the case of a Decay). The polar angle &theta; is uniformly distributed in cos(&theta;) from [-1, 1], while the azimuthal angle is uniformly distributed in the range [0, 2&pi;]. With the initial energy of the system and the outgoing angles, the system is completely described and the energies of the products can be found using simple conservation of momentum and energy. In a Reaction the angles of the ejectile is sampled. In a Decay the angles of the input product are sampled.
+
+### Propogation through the Chain
+
+In the above we we're mainly disucssing a single step. Howeve, you may be wondering how this affects subsequent steps, that is how we propogate the result of sampling the Reaction to the Decay. This is done by taking the resulting kinematics of the residual from the Reaction and passing them to the parent of the Decay. You can think of it as setting the "beam energy" for the Decay.
+
+### Excitations
+
+In many reactions we're not interested in just the ground state of a nucleus, but also it's excited states (which may Decay!). In attpc_engine an excited state may be specified for a residual in a Reaction or a non-input residual (the one that's calculated for you) in a Decay. Excitations can be specified as either a uniform distribution or Gaussian distribution by default, but this is an extensible feature (see the reference [here](../../api/kinematics/excitation.md)) so more exotic distributions can be implemented. Excitations can be tricky however, when it comes to allowed energies. In particular, if an excitation is near the energy threshold

--- a/docs/user_guide/kinematics/index.md
+++ b/docs/user_guide/kinematics/index.md
@@ -4,9 +4,9 @@ The kinematics system is focused on sampling the phase space allowed by a given 
 
 ## Reactions
 
-The core underlying model of the kinematics is that of a [reaction](../../api/kinematics/reaction.md). In attpc_engine there are two types of reactions. 
+The core underlying model of the kinematics is that of a [reaction](../../api/kinematics/reaction.md). In attpc_engine there are two types of reactions.
 
-The first is called Reaction, which is of the kind $a(b, c)d$ where you have an incoming projectile (sometimes referred to as the beam) incident upon a target particle. The nuclei react and produce two products, one of which we refer to as an ejectile (this is typically the $c$ in the reaction equation) and the other we refer to as the residual (typically the $d$ in the above equation). In attpc_engine you define a reaction by providing the projectile, target, and ejectile nuclei. The residual is calculated for you based on the other inputs. 
+The first is called Reaction, which is of the kind $a(b, c)d$ where you have an incoming projectile (sometimes referred to as the beam) incident upon a target particle. The nuclei react and produce two products, one of which we refer to as an ejectile (this is typically the $c$ in the reaction equation) and the other we refer to as the residual (typically the $d$ in the above equation). In attpc_engine you define a reaction by providing the projectile, target, and ejectile nuclei. The residual is calculated for you based on the other inputs.
 
 The second is called a Decay, which is of the kind $a \rightarrow b+c$ where the parent nucleus, $a$, decays into two products $b$ and $c$. In attpc_engine you specify a Decay by the parent and one of the decay products. The other product is calculated for you.
 
@@ -32,4 +32,23 @@ In the above we we're mainly disucssing a single step. Howeve, you may be wonder
 
 ### Excitations
 
-In many reactions we're not interested in just the ground state of a nucleus, but also it's excited states (which may Decay!). In attpc_engine an excited state may be specified for a residual in a Reaction or a non-input residual (the one that's calculated for you) in a Decay. Excitations can be specified as either a uniform distribution or Gaussian distribution by default, but this is an extensible feature (see the reference [here](../../api/kinematics/excitation.md)) so more exotic distributions can be implemented. Excitations can be tricky however, when it comes to allowed energies. In particular, if an excitation is near the energy threshold
+In many reactions we're not interested in just the ground state of a nucleus, but also it's excited states (which may Decay!). In attpc_engine an excited state may be specified for a residual in a Reaction or a non-input residual (the one that's calculated for you) in a Decay. Excitations can be specified as either a uniform distribution or Gaussian distribution by default, but this is an extensible feature (see the reference [here](../../api/kinematics/excitation.md)) so more exotic distributions can be implemented.
+
+## Resampling
+
+In a very simple reaction model (say elastic scattering to a ground state with no width and with any non-zero beam energy), all possible draws of sampling the parameters result in a valid configuration of parameters. However, consider the case where the following occurs: a two-step chain is defined where each step has a relatively broad excitation distribution. Depending on the beam energy and masses involved, it is possible that only a *subrange* of the second step excitation energy defined is allowed by energy conservation for a given draw of beam energy and first step excitation. In this case there are two options: raise an Error and drop the event, or resample the event hoping that a new draw of the sample will result in a valid configuration. In attpc_engine, we use the resampling option for two major reasons:
+
+- Resampling guarantees that we will have the total number of events requested in the data
+- Only through resampling can you properly describe complicated phase spaces of multiple chained excitations
+
+However, resampling comes at a cost of performance. Now when you request 1000 events, you might actualy run 100000 calculations if the allowed subset of the total defined phase space is very small! Or, even worse, if you define an excitation which is energetically banned for your beam energy, you will be stuck in an infinite loop! To handle this, the pipeline has an upper limit on the number of allowed resamples per event. If the limit is reached, an error is raised, and the simulation stops. The default value is 1000 samples per event, but this can be changed (see [here](../../api/kinematics/pipeline.md)). However, we recommend caution in changing this value. If you find your allowed phase space is very small compared to the total defined phase space, it is probably best to consider shrinking the total phase space first. This can be done by limiting the range of allowed beam energies (restricting the z-range) or defining clipped excitation distributions (like [this](https://en.wikipedia.org/wiki/Truncated_normal_distribution)). Note that the limit doesn't mean you *always* run 1000 samples per event. It means that *at maximum* you can run 1000 samples per event.
+
+## Converting to Dataframes
+
+By default, the kinematics simulation writes data out to the [HDF5](https://www.hdfgroup.org/) format, which works really well for storing the data in a neat, clean structure that is easy to parse in the next step of the simulation. However, this format is not ideal for analyzing; it is difficult to extract and the values stored are not well described in general. To support analyzing the output of the kinematics, a script is provided with the install to convert the HDF5 output to a dataframe in the [Parquet](https://parquet.apache.org/) format, which can then be opened using many popular dataframe libraries (pandas, polars, etc.). Usage is:
+
+```bash
+convert-kinematics <your_hdf5_file> <output_parquet_file>
+```
+
+Make sure you have your virtual environment with attpc_conduit installed active!

--- a/docs/user_guide/numba.md
+++ b/docs/user_guide/numba.md
@@ -1,0 +1,3 @@
+# Numba
+
+To make attpc_engine fast, we use [Numba](https://numba.readthedocs.io). Numba is a Just-In-Time compiler that supports a large set of Python and numpy. Whenever you see code in attpc_engine that has been decorated with `@njit` that means that we want Numba to JIT that code. JIT-ing can greatly improve performance of code operating on large datasets. However, there is some cost. Numba needs to be able to determine the type of data you're using (i.e. float, int, etc) and doesn't support many of the useful extensions and libraries in Python. So you have to use the JIT sparingly, only where there's a serious performance bottleneck. 

--- a/docs/user_guide/setup.md
+++ b/docs/user_guide/setup.md
@@ -1,0 +1,36 @@
+# Setup and Installation
+
+## Requirements
+
+attpc_engine requires a Python version between 3.10 and 3.12 (inclusive)
+
+## Installation
+
+attpc_engine can be installed using pip:
+
+```bash
+pip install attpc_engine
+```
+
+It is recommended to install attpc_engine to a virtual environment to avoid dependency clashes.
+
+## attpc_engine @ FRIB
+
+In the FRIB computing infrastructure you may not have control over which Python versions are installed globally to your machine. In this case we recommend using the (typically) installed conda distribution to create a conda env that has the version of Python you need. 
+
+Creating a conda environment with the needed Python is done by running something like
+
+```bash
+conda create --name engine-env python=3.11
+```
+
+Then you can activate that env using `conda activate engine-env` and use `pip install attpc_engine` as normal.
+
+## Package dependencies
+
+- [spyral-utils](https://attpc.github.com/spyral-utils)
+- [h5py](https://www.h5py.org/)
+- [numba](https://numba.readthedocs.io)
+- [tqdm](https://github.com/tqdm/tqdm)
+
+And all of these packages dependencies. Thanks to everyone who develops these tools!

--- a/docs/user_guide/systems.md
+++ b/docs/user_guide/systems.md
@@ -1,0 +1,11 @@
+# Systems
+
+As shown in the [getting started](./getting_started.md) disucssion, attpc_engine really has two separate subsystems: the [kinematics](./kinematics/index.md) sampler and the [detector](./detector/index.md) effects. These two systems are (mostly) distinct and are two separate modules rolled into one package.
+
+## Why are they separate
+
+There are a couple of reasons why they're separated. First, they don't really need to know much about each other. The only real information leakage is the target material (what gas you're using and how much volume you allow the reaction vertex to travel through). So in that sense, they really shouldn't contact each other!
+
+But more importantly, separating them allows you to save intermediate steps. Consider the following:
+
+Say you are testing the detection effciency for a reaction where you already have some data. You generate the kinematics, and you need a lot of samples so it takes forever, hours or maybe even a day. Then you run it through the detector system and see that oh no you forgot to set the electric field correctly! If the systems were directly coupled, you would have to rerun everything, including the kinematics! With them separated, you only need to rerun the detector system, saving you time and effort. 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "format", "docs"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:eb421d400b8a75e0581e3050ffa2a167cb5c9d1cd72acd36d7f28e12a9133e8c"
+content_hash = "sha256:3dbf3b58f51aad9ade63e92753f893cc0c5acf9cc71286eced300ebb78e7c642"
 
 [[package]]
 name = "babel"
@@ -868,7 +868,7 @@ files = [
 
 [[package]]
 name = "spyral-utils"
-version = "0.3.0"
+version = "1.0.0"
 requires_python = "<3.13,>=3.10"
 summary = "A collection of useful utilities for the Spyral analysis framework"
 groups = ["default"]
@@ -881,8 +881,8 @@ dependencies = [
     "vector>=1.3.0",
 ]
 files = [
-    {file = "spyral_utils-0.3.0-py3-none-any.whl", hash = "sha256:4e0b1f00b83558a82393d4dacc4fa41ac9f7ac5bafbd385c97329fcfa2bee055"},
-    {file = "spyral_utils-0.3.0.tar.gz", hash = "sha256:5e8501ba69df4998bfa04cb76beb8b286168ca7e6f4504804cbe4f1cba4194a9"},
+    {file = "spyral_utils-1.0.0-py3-none-any.whl", hash = "sha256:02e8aea9572eedc86c0b8366119f136afa3b77ed262b13697faf8b33c734196d"},
+    {file = "spyral_utils-1.0.0.tar.gz", hash = "sha256:155867f068ebf29caf2b7bc2561234597de1f92f6f424e22d3588c3de4ebe843"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "gwm17", email = "gordonmccann215@gmail.com"},
 ]
 dependencies = [
-    "spyral-utils>=0.3.0",
+    "spyral-utils>=1.0.0",
     "h5py>=3.11.0",
     "numba>=0.59.1",
     "tqdm>=4.66.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "attpc_engine"
 version = "0.1.0"
 description = "AT-TPC Monte-Carlo simulation engine"
 authors = [
-    {name = "gwm17", email = "gordonmccann215@gmail.com"},
+    {name = "Gordon McCann", email = "gordonmccann215@gmail.com"},
+    {name = "Zach Serikow"},
 ]
 dependencies = [
     "spyral-utils>=1.0.0",
@@ -18,6 +19,9 @@ license = {text = "GPL-3.0"}
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
+
+[project.scripts]
+convert-kinematics = "attpc_engine.kinematics.convert_kinematics:main"
 
 
 [tool.pdm]

--- a/src/attpc_engine/kinematics/convert_kinematics.py
+++ b/src/attpc_engine/kinematics/convert_kinematics.py
@@ -1,0 +1,74 @@
+from .. import nuclear_map
+
+import h5py as h5
+import polars as pl
+from pathlib import Path
+from tqdm import trange
+import numpy as np
+import argparse
+
+
+def convert_kinematics_hdf5_to_polars(input_path: Path, output_path: Path) -> None:
+
+    if not input_path.exists():
+        raise Exception(f"Input path {input_path} does not exist!")
+
+    hdf_file = h5.File(input_path, "r")
+
+    input_data_group = hdf_file["data"]
+    proton_numbers: np.ndarray = input_data_group.attrs["proton_numbers"]  # type: ignore
+    mass_numbers: np.ndarray = input_data_group.attrs["mass_numbers"]  # type: ignore
+    n_events: int = input_data_group.attrs["n_events"]  # type: ignore
+    n_nuclei = len(proton_numbers)
+    nuclei = [
+        nuclear_map.get_data(proton_numbers[idx], mass_numbers[idx])  # type: ignore
+        for idx in range(n_nuclei)
+    ]
+
+    # dataframe dictionary
+    dataframe = {
+        "event": [],
+        "Z": [],
+        "A": [],
+        "isotope": [],
+        "energy": [],
+        "px": [],
+        "py": [],
+        "pz": [],
+        "vertex_x": [],
+        "vertex_y": [],
+        "vertex_z": [],
+    }
+
+    for event in trange(n_events):
+        dataset: h5.Dataset = input_data_group[f"event_{event}"]  # type: ignore
+        vx = dataset.attrs["vertex_x"]
+        vy = dataset.attrs["vertex_y"]
+        vz = dataset.attrs["vertex_z"]
+        for idx in range(n_nuclei):
+            dataframe["event"].append(event)
+            dataframe["Z"].append(proton_numbers[idx])
+            dataframe["A"].append(mass_numbers[idx])
+            dataframe["isotope"].append(nuclei[idx].isotopic_symbol)
+            dataframe["energy"].append(dataset[idx, 3])
+            dataframe["px"].append(dataset[idx, 0])
+            dataframe["py"].append(dataset[idx, 1])
+            dataframe["pz"].append(dataset[idx, 2])
+            dataframe["vertex_x"].append(vx)
+            dataframe["vertex_y"].append(vy)
+            dataframe["vertex_z"].append(vz)
+
+    df = pl.DataFrame(data=dataframe)
+    df.write_parquet(output_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert the simulation kinematics HDF5 data to a dataframe"
+    )
+    parser.add_argument("input", type=Path, help="The simulation HDF5 data")
+    parser.add_argument(
+        "output", type=Path, help="The output dataframe file path (parquet)"
+    )
+    args = parser.parse_args()
+    convert_kinematics_hdf5_to_polars(args.input, args.output)

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -47,17 +47,17 @@ def test_pipeline():
                 ),
                 Decay(
                     parent=nuclear_map.get_data(5, 9),
-                    residual_1=nuclear_map.get_data(1, 1),
+                    residual_1=nuclear_map.get_data(2, 4),
                 ),
             ],
-            [ExcitationGaussian(16.8, 0.2), ExcitationGaussian(0.0, 0.5)],
+            [ExcitationGaussian(16.8, 0.2), ExcitationGaussian(0.0, 1.25)],
             24.0,
         )
-        distance, result = pipeline.run()
-        assert np.all(pipeline.get_proton_numbers() == np.array([5, 2, 2, 5, 1, 4]))
-        assert np.all(pipeline.get_mass_numbers() == np.array([10, 3, 4, 9, 1, 8]))
+        vertex, result = pipeline.run()
+        assert np.all(pipeline.get_proton_numbers() == np.array([5, 2, 2, 5, 2, 3]))
+        assert np.all(pipeline.get_mass_numbers() == np.array([10, 3, 4, 9, 4, 5]))
         assert len(result) == 6
-        assert np.all(distance == 0.0)
+        assert np.all(vertex == 0.0)
     except PipelineError as e:
         print(f"Failed with error {e}")
         assert False
@@ -132,6 +132,34 @@ def test_pipeline_order():
             ],
             [ExcitationGaussian(16.8, 0.2), ExcitationGaussian(0.0, 0.0)],
             24.0,
+        )
+        result = pipeline.run()
+        assert np.all(pipeline.get_proton_numbers() == np.array([5, 2, 2, 5, 2, 3]))
+        assert np.all(pipeline.get_mass_numbers() == np.array([10, 3, 4, 9, 4, 5]))
+        assert len(result) == 6
+    except PipelineError as e:
+        pass
+    else:
+        print("Failed out-of-order test")
+        assert False
+
+
+def test_pipeline_sample_limit():
+    # Test if we catch banned energetics
+    # Define an illegal excitation for a given beam energy
+    try:
+        pipeline = KinematicsPipeline(
+            [
+                Reaction(
+                    target=nuclear_map.get_data(5, 10),
+                    projectile=nuclear_map.get_data(2, 3),
+                    ejectile=nuclear_map.get_data(2, 4),
+                ),
+            ],
+            [
+                ExcitationGaussian(16.8, 0.2),
+            ],
+            2.0,
         )
         result = pipeline.run()
         assert np.all(pipeline.get_proton_numbers() == np.array([5, 2, 2, 5, 2, 3]))


### PR DESCRIPTION
Fix the sampling in the KinematicsPipeline. Previously had two bad behaviors, which mostly manifested in infinite loops if the distributions had energetically banned regions. Now resamples up to a user definable limit, with appropriate warnings/behavior if the limit is reached.

Add a script to convert kinematics HDF5 output to parquet dataframes.

Fill out the general and kinematics docs.