### PR TITLE
Reaction Threshold Fix

### DIFF
--- a/src/attpc_engine/kinematics/reaction.py
+++ b/src/attpc_engine/kinematics/reaction.py
@@ -3,6 +3,7 @@ from .. import nuclear_map
 from spyral_utils.nuclear import NucleusData
 import vector
 import numpy as np
+from math import isclose
 
 
 class Reaction:
@@ -72,6 +73,9 @@ class Reaction:
     ) -> bool:
         """Check if a given exctiation, projectile energy is energetically allowed
 
+        Calculate center-of-mass energy of the system and verify that there is enough
+        energy to make the outgoing products
+
         Parameters
         ----------
         projectile_energy: float
@@ -93,6 +97,7 @@ class Reaction:
             (self.target.mass + projectile_energy + self.projectile.mass) ** 2.0
             - pz**2.0
         )
+
         outgoing_mass = self.ejectile.mass + self.residual.mass + residual_excitation
         return outgoing_mass < E_cm
 

--- a/src/attpc_engine/kinematics/reaction.py
+++ b/src/attpc_engine/kinematics/reaction.py
@@ -84,19 +84,17 @@ class Reaction:
         bool
             True if allowed, False if not
         """
-        q_value = (
-            self.target.mass
-            + self.projectile.mass
-            - (self.ejectile.mass + self.residual.mass + residual_excitation)
+        # System z-momentum in lab
+        pz = np.sqrt(
+            projectile_energy * (projectile_energy + 2.0 * self.projectile.mass)
         )
-
-        e_threshold = (
-            -q_value
-            * (self.ejectile.mass + self.residual.mass)
-            / (self.ejectile.mass + self.residual.mass - self.projectile.mass)
+        # Lorentz invariant total length (i.e. CoM system energy)
+        E_cm = np.sqrt(
+            (self.target.mass + projectile_energy + self.projectile.mass) ** 2.0
+            - pz**2.0
         )
-
-        return projectile_energy >= e_threshold
+        outgoing_mass = self.ejectile.mass + self.residual.mass + residual_excitation
+        return outgoing_mass < E_cm
 
     def calculate(
         self,


### PR DESCRIPTION
Edge case was discovered when trying to determine kinematic limit of deuteron breakup energy. Engine threshold was too high (15.57 MeV deuteron Ex for 93 MeV 10Be beam) compared to E_cm limit (approx. 15.561 MeV Ex). Switch to using direct E_cm >= outgoing mass comparison. Not sure why previous eqn didn't work (ripped right out of Iliadis Nuc Astro book). Meh. Either way, it works now