### PR TITLE
Write point clouds to multiple files

### DIFF
--- a/src/attpc_engine/detector/parameters.py
+++ b/src/attpc_engine/detector/parameters.py
@@ -177,6 +177,15 @@ class Config:
         in space. If that location corresponds to no pad, then the pad ID is -1.
         The grid file should also contain a 3 element array with
         the grid edges in mm and the step size of the grid.
+
+        The pad grid is indexed by the lower edge of each spatial bin. Due to this,
+        and because the pad grid must be symmetric, this means that the Nth column
+        and row are not the same as the 0th row and column. For example, if the pad
+        grid is to be symmetric from -280 to 280 mm with spatial bins of 0.1 mm,
+        the Oth row and column correspond to bin edges of -280 (the bin is [-280, 279.9))
+        while the Nth row and column correspond to bin edges of 279.9 (the bin is
+        [-279.9, 280). In this sense, the pad grid is inclusive on the lowest bin
+        edge and exclusive on the highest bin edge.
         """
         if self.pad_params.grid_path == DEFAULT:
             grid_handle = resources.files("attpc_engine.detector.data").joinpath(

--- a/src/attpc_engine/detector/parameters.py
+++ b/src/attpc_engine/detector/parameters.py
@@ -151,7 +151,7 @@ class Config:
         self.pad_grid: np.ndarray | None = None
         self.pad_grid_edges: np.ndarray | None = None
         self.pad_centers: np.ndarray | None = None
-        self.drift_velocity: float = 0.0
+        self.drift_velocity = 0.0
         # Set everything
         self.calculate_drift_velocity()
         self.load_pad_grid()

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -337,8 +337,7 @@ def run_simulation(
 
     n_events: int = input_data_group.attrs["n_events"]  # type: ignore
     print(f"Found {n_events} kinematics events.")
-    writer.set_number_of_events(n_events)
-    print(f"Output will be written to {writer.get_filename()}.")
+    print(f"Output will be written to {writer.get_directory_name()}.")
 
     rng = default_rng()
 
@@ -374,5 +373,6 @@ def run_simulation(
             continue
 
         writer.write(cloud, config, event_number)
+    writer.set_number_of_events()
     print("Done.")
     print("----------------------------------------")

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -373,6 +373,6 @@ def run_simulation(
             continue
 
         writer.write(cloud, config, event_number)
-    writer.set_number_of_events()
+    writer.close()
     print("Done.")
     print("----------------------------------------")

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -78,7 +78,9 @@ def position_to_index(
 ) -> tuple[int, int]:
     """
     Given an input position in (x, y), outputs the index on the pad map
-    corresponding to that position.
+    corresponding to that position. For information about the format of
+    the pad map, see the load_pad_grid method of the Config class in
+    the parameters file.
 
     Parameters
     ----------
@@ -100,8 +102,12 @@ def position_to_index(
     high_edge: float = grid_edges[1]
     bin_size: float = grid_edges[2]
 
-    # Check if position is off pad plane. This condition requires a symmetric pad map!
-    if (abs(math.floor(x)) > high_edge) or (abs(math.floor(y)) > high_edge):
+    # Pad map is exclusive on highest edge
+    if math.floor(x) >= high_edge or math.floor(y) >= high_edge:
+        return (-1, -1)
+
+    # Pad map is inclusive on lowest edge
+    if math.floor(x) < high_edge or math.floor(y) < high_edge:
         return (-1, -1)
 
     x_idx = int((math.floor(x) - low_edge) / bin_size)

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -110,7 +110,6 @@ def position_to_index(
     if math.floor(x) < low_edge or math.floor(y) < low_edge:
         return (-1, -1)
 
-    print("good")
     x_idx = int((math.floor(x) - low_edge) / bin_size)
     y_idx = int((math.floor(y) - low_edge) / bin_size)
 

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -107,9 +107,10 @@ def position_to_index(
         return (-1, -1)
 
     # Pad map is inclusive on lowest edge
-    if math.floor(x) < high_edge or math.floor(y) < high_edge:
+    if math.floor(x) < low_edge or math.floor(y) < low_edge:
         return (-1, -1)
 
+    print("good")
     x_idx = int((math.floor(x) - low_edge) / bin_size)
     y_idx = int((math.floor(y) - low_edge) / bin_size)
 

--- a/src/attpc_engine/detector/writer.py
+++ b/src/attpc_engine/detector/writer.py
@@ -127,6 +127,7 @@ class SpyralWriter:
         self.max_file_size: int = max_file_size
         self.run_number = 0
         self.event_number_low = 0  # Kinematics generator always starts with event 0
+        self.event_number_high = 0  # By default set to 0
         self.create_file()
 
     def create_file(self) -> None:

--- a/src/attpc_engine/detector/writer.py
+++ b/src/attpc_engine/detector/writer.py
@@ -10,6 +10,9 @@ from numba import njit
 
 
 class SimulationWriter(Protocol):
+    """
+    Protocol class for what methods a simulation writer class should contain.
+    """
 
     def write(self, data: np.ndarray, config: Config, event_number: int) -> None:
         pass
@@ -17,19 +20,44 @@ class SimulationWriter(Protocol):
     def set_number_of_events(self, n_events: int) -> None:
         pass
 
-    def get_filename(self) -> Path: ...
+    def get_directory_name(self) -> Path: ...
 
 
 @njit
 def convert_to_spyral(
     points: np.ndarray,
     window_edge: float,
-    mm_edge: float,
-    length: float,
+    mm_edge: int,
+    length: int,
     response: np.ndarray,
     pad_centers: np.ndarray,
-    adc_threshold: float,
+    adc_threshold: int,
 ) -> np.ndarray:
+    """
+    Converts a simulated point in the point cloud to Spyral formatting.
+
+    Parameters
+    ----------
+    points: np.ndarray
+        An Nx3 array representing the point cloud. Each row is a point, with elements
+        [pad id, time bucket, electrons].
+    window_edge: int
+        The windows edge of the detector in time buckets.
+    mm_edge: int
+        The micromegas edge of the detector in time buckets.
+    length: int
+        Length of active volume of detector in meters
+    response: np.ndarray
+        Response of GET electronics.
+    pad_centers: np.ndarray
+        (x, y) coordinates of each pad's center on the pad plane in mm.
+    adc_threshold: int
+        Minimum ADC signal amplitude a point must have in the point cloud.
+
+    Returns
+    -------
+    np.ndarray
+    """
 
     storage = np.empty((len(points), 8))
     for idx, point in enumerate(points):
@@ -54,14 +82,77 @@ def convert_to_spyral(
 
 
 class SpyralWriter:
+    """
+    Writer for default Spyral analysis. Writes the simulated data into multiple
+    files to take advantage of Spyral's multiprocessing.
 
-    def __init__(self, file_path: Path, config: Config):
-        self.path = file_path
-        self.file = h5.File(self.path, "w")
-        self.cloud_group = self.file.create_group("cloud")
-        self.response = get_response(config).copy()
+    Parameters
+    ----------
+    directory_path: Path
+        Path to directory to store simulated point cloud files.
+    config: Config
+        The simulation configuration.
+    max_file_size: int
+        The maximum file size of a point cloud file in bytes. Defualt value is 10 Gb.
+
+    Attributes
+    ----------
+    response: np.ndarray
+        Response of GET electronics.
+    run_number: int
+        Run number of current point cloud file being written to.
+    file_path: Path
+        Path to current point cloud file being written to.
+    file: h5.File
+        h5 file object. It is the actual point cloud file currently
+        being written to.
+    cloud_group: h5.Group
+        "cloud" group in current point cloud file.
+
+    Methods
+    -------
+    create_file() -> None:
+        Creates a new point cloud file.
+    write(data: np.ndarray, config: Config, event_number: int) -> None
+        Writes a simulated point cloud to the point cloud file.
+    set_number_of_events(n_events: int) -> None
+        Not currently used, but required to have this method.
+    get_filename() -> Path
+        Returns directory that point cloud files are written to.
+    """
+
+    def __init__(self, directory_path: Path, config: Config, max_file_size: int = 10e9):
+        self.directory_path: Path = directory_path
+        self.response: np.ndarray = get_response(config).copy()
+        self.max_file_size: int = max_file_size
+        self.run_number = 0
+        self.event_number_low = 0  # Kinematics generator always starts with event 0
+        self.create_file()
+
+    def create_file(self) -> None:
+        """
+        Creates a new point cloud file.
+        """
+        self.run_number += 1
+        path: Path = self.directory_path / f"run_{self.run_number:04d}.h5"
+        self.file_path: Path = path
+        self.file = h5.File(path, "w")
+        self.cloud_group: h5.Group = self.file.create_group("cloud")
 
     def write(self, data: np.ndarray, config: Config, event_number: int) -> None:
+        """
+        Writes a simulated point cloud to the point cloud file.
+
+        Parameters
+        ----------
+        data: np.ndarray
+            An Nx3 array representing the point cloud. Each row is a point, with elements
+            [pad id, time bucket, electrons].
+        config: Config
+            The simulation configuration.
+        event_number: int
+            Event number of simulated event from the kinematics file.
+        """
         if config.pad_centers is None:
             raise ValueError("Pad centers are not assigned at write!")
         spyral_format = convert_to_spyral(
@@ -74,18 +165,34 @@ class SpyralWriter:
             config.elec_params.adc_threshold,
         )
 
+        self.event_number_high = event_number
+
         dset = self.cloud_group.create_dataset(
             f"cloud_{event_number}", data=spyral_format
         )
+
+        # If current file is too large, make a new one
+        if self.file_path.stat().st_size > self.max_file_size:
+            self.set_number_of_events()
+            self.create_file()
+
         # No ic stuff from simulation
         dset.attrs["ic_amplitude"] = -1.0
         dset.attrs["ic_multiplicity"] = -1.0
         dset.attrs["ic_integral"] = -1.0
         dset.attrs["ic_centroid"] = -1.0
 
-    def set_number_of_events(self, n_events: int) -> None:
-        self.cloud_group.attrs["min_event"] = 0
-        self.cloud_group.attrs["max_event"] = n_events - 1
+    def set_number_of_events(self) -> None:
+        """
+        Writes the first and last written events as attributes to the current
+        point cloud file.
+        """
+        self.cloud_group.attrs["min_event"] = self.event_number_low
+        self.cloud_group.attrs["max_event"] = self.event_number_high
+        self.event_number_low = self.event_number_high
 
-    def get_filename(self) -> Path:
-        return self.path
+    def get_directory_name(self) -> Path:
+        """
+        Returns directory that point cloud files are written to.
+        """
+        return self.directory_path

--- a/src/attpc_engine/detector/writer.py
+++ b/src/attpc_engine/detector/writer.py
@@ -12,15 +12,44 @@ from numba import njit
 class SimulationWriter(Protocol):
     """
     Protocol class for what methods a simulation writer class should contain.
+
+    Methods
+    -------
+    write(data: np.ndarray, config: Config, event_number: int) -> None
+        Writes a simulated point cloud to the point cloud file.
+    get_filename() -> Path
+        Returns directory that point cloud files are written to.
+    close() -> None
+        Closes the writer.
     """
 
     def write(self, data: np.ndarray, config: Config, event_number: int) -> None:
+        """
+        Writes a simulated point cloud to the point cloud file.
+
+        Parameters
+        ----------
+        data: np.ndarray
+            An Nx3 array representing the point cloud. Each row is a point, with elements
+            [pad id, time bucket, electrons].
+        config: Config
+            The simulation configuration.
+        event_number: int
+            Event number of simulated event from the kinematics file.
+        """
         pass
 
-    def set_number_of_events(self, n_events: int) -> None:
+    def get_directory_name(self) -> Path:
+        """
+        Returns directory that point cloud files are written to.
+        """
         pass
 
-    def get_directory_name(self) -> Path: ...
+    def close(self) -> None:
+        """
+        Closes the writer.
+        """
+        pass
 
 
 @njit
@@ -119,9 +148,12 @@ class SpyralWriter:
         Not currently used, but required to have this method.
     get_filename() -> Path
         Returns directory that point cloud files are written to.
+    close() -> None
+        Closes the writer and ensures the current point cloud file being
+        written to has the first and last written events as attributes.
     """
 
-    def __init__(self, directory_path: Path, config: Config, max_file_size: int = 10e9):
+    def __init__(self, directory_path: Path, config: Config, max_file_size: int = 5e9):
         self.directory_path: Path = directory_path
         self.response: np.ndarray = get_response(config).copy()
         self.max_file_size: int = max_file_size
@@ -197,3 +229,10 @@ class SpyralWriter:
         Returns directory that point cloud files are written to.
         """
         return self.directory_path
+
+    def close(self) -> None:
+        """
+        Closes the writer and ensures the current point cloud file being
+        written to has the first and last written events as attributes.
+        """
+        self.set_number_of_events()


### PR DESCRIPTION
Changed functionality of how point clouds are written to disk. They are written to one file until that file reaches the specified size, then they are written to a new file. This process is repeated until all events are simulated. Also included are various documentation additions.