### PR TITLE
Add the flush back in 

### DIFF
--- a/src/attpc_engine/detector/writer.py
+++ b/src/attpc_engine/detector/writer.py
@@ -218,6 +218,8 @@ class SpyralWriter:
         dset.attrs["ic_integral"] = -1.0
         dset.attrs["ic_centroid"] = -1.0
 
+        dset.flush()
+
     def set_number_of_events(self) -> None:
         """
         Writes the first and last written events as attributes to the current


### PR DESCRIPTION
The HDF5 corruption bug still seems to persist. I am adding back in the flush to the writer in the hopes it fixes it.