### PR TITLE
Fix event number bug

### DIFF
--- a/src/attpc_engine/detector/writer.py
+++ b/src/attpc_engine/detector/writer.py
@@ -190,9 +190,10 @@ class SpyralWriter:
         """
         # If current file is too large, make a new one
         if self.file_path.stat().st_size >= self.max_file_size:
-            self.set_number_of_events()
-            self.file.close()
+            self.close()
             self.create_file()
+            self.event_number_low = event_number
+            self.event_number_high = event_number
 
         if config.pad_centers is None:
             raise ValueError("Pad centers are not assigned at write!")
@@ -218,8 +219,6 @@ class SpyralWriter:
         dset.attrs["ic_integral"] = -1.0
         dset.attrs["ic_centroid"] = -1.0
 
-        dset.flush()
-
     def set_number_of_events(self) -> None:
         """
         Writes the first and last written events as attributes to the current
@@ -227,7 +226,6 @@ class SpyralWriter:
         """
         self.cloud_group.attrs["min_event"] = self.event_number_low
         self.cloud_group.attrs["max_event"] = self.event_number_high
-        self.event_number_low = self.event_number_high
 
     def get_directory_name(self) -> Path:
         """


### PR DESCRIPTION
Fixed a bug where the min_event_number could be written incorrectly for a given file, making it seem as though data which should be present did not exist, and could result in weird dead keys. Tests are ongoing, so this will start as a draft.