### PR TITLE
Fix Transport integration

### DIFF
--- a/src/attpc_engine/detector/pairing.py
+++ b/src/attpc_engine/detector/pairing.py
@@ -4,6 +4,24 @@ from numba import njit
 
 @njit
 def pair(tb: int, pad: int) -> int:
+    """Combine two integers into one integer
+
+    Uses Szudzik pairing function to combine Time Bucket and Pad
+    into a id.
+
+    Parameters
+    ----------
+    tb: int
+        The time bucket of the data
+    pad: int
+        The pad id of the data
+
+    Returns
+    -------
+    int
+        The id of this data from the tb and pad
+
+    """
     if tb < 0 or pad < 0:
         return -1
     return tb * tb + tb + pad if tb == max(tb, pad) else pad * pad + tb
@@ -11,6 +29,22 @@ def pair(tb: int, pad: int) -> int:
 
 @njit
 def unpair(id: int) -> tuple[int, int]:
+    """Inverse of the pairing function
+
+    This is the inverse pairing function for Szudzik pairing
+
+    Parameters
+    ----------
+    id: int
+        A id generated from the pair function
+
+    Returns
+    -------
+    tuple[int, int]
+        A pair of numbers which was used to generate the original id.
+        In our case the first is the time bucket, the second is the pad id.
+        Note that the order is important!
+    """
     if id < 0:
         return (-1, -1)
 

--- a/src/attpc_engine/detector/pairing.py
+++ b/src/attpc_engine/detector/pairing.py
@@ -1,0 +1,21 @@
+import numpy as np
+from numba import njit
+
+
+@njit
+def pair(tb: int, pad: int) -> int:
+    if tb < 0 or pad < 0:
+        return -1
+    return tb * tb + tb + pad if tb == max(tb, pad) else pad * pad + tb
+
+
+@njit
+def unpair(id: int) -> tuple[int, int]:
+    if id < 0:
+        return (-1, -1)
+
+    sqrt_id = np.floor(np.sqrt(id))
+    if id - sqrt_id**2 < sqrt_id:
+        return (id - sqrt_id**2, sqrt_id)
+    else:
+        return (sqrt_id, id - sqrt_id**2 - sqrt_id)

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -304,6 +304,7 @@ class SimParticle:
             track,
             electrons,
         )
+
         # Wiggle point TBs over interval [0.0, 1.0). This simulates effect of converting
         # the (in principle) int TBs to floats.
         points[:, 1] += rng.uniform(low=0.0, high=1.0, size=len(points))

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -101,11 +101,7 @@ class SimEvent:
         points: np.ndarray = np.empty((0, 3))
         for nuc in self.nuclei:
             new_points = nuc.generate_point_cloud(config, rng)
-            if len(new_points) != 0:
-                points = np.vstack((points, new_points))
-
-        # Remove dead points (no pads hit)
-        points = points[points[:, 0] != -1.0]
+            points = np.vstack((points, new_points))
 
         # Remove points outside legal bounds in time. TODO check if this is needed
         points = points[points[:, 1] < NUM_TB]

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -1,4 +1,4 @@
-from .utils import pair, unpair
+from .pairing import pair, unpair
 from .beam_pads import BEAM_PADS_ARRAY
 
 import numpy as np

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -1,8 +1,10 @@
-import math
-import numpy as np
-
-from numba import njit
+from .utils import pair, unpair
 from .beam_pads import BEAM_PADS_ARRAY
+
+import numpy as np
+from numba import njit
+from numba.typed import Dict
+from numba.core import types
 
 STEPS = 10
 
@@ -36,7 +38,7 @@ def bivariate_normal_pdf(
         ((point[0] - mu[0]) ** 2) + ((point[1] - mu[1]) ** 2)
     )
 
-    return c1 * math.exp(c2)
+    return c1 * np.exp(c2)
 
 
 @njit
@@ -103,15 +105,15 @@ def position_to_index(
     bin_size: float = grid_edges[2]
 
     # Pad map is exclusive on highest edge
-    if math.floor(x) >= high_edge or math.floor(y) >= high_edge:
+    if np.floor(x) >= high_edge or np.floor(y) >= high_edge:
         return (-1, -1)
 
     # Pad map is inclusive on lowest edge
-    if math.floor(x) < low_edge or math.floor(y) < low_edge:
+    if np.floor(x) < low_edge or np.floor(y) < low_edge:
         return (-1, -1)
 
-    x_idx = int((math.floor(x) - low_edge) / bin_size)
-    y_idx = int((math.floor(y) - low_edge) / bin_size)
+    x_idx = int((np.floor(x) - low_edge) / bin_size)
+    y_idx = int((np.floor(y) - low_edge) / bin_size)
 
     return (x_idx, y_idx)
 
@@ -123,7 +125,8 @@ def point_transport(
     time: float,
     center: tuple[float, float],
     electrons: int,
-) -> np.ndarray:
+    points: dict[int, int],
+):
     """
     Transports all electrons created at a point in a simulated nucleus' track
     straight to the pad plane.
@@ -141,11 +144,9 @@ def point_transport(
         (x,y) position of point being transported.
     electrons: int
         Number of electrons made at point being transported.
-
-    Returns
-    -------
-    numpy.ndarray
-        An Nx3 array representing the simplified point cloud
+    points: dict[int, int]
+        A dictionary mapping a unique pad,tb key to the number of electrons, which
+        will be filled by this function
     """
     # Find pad number of hit pad, if it exists
     point = np.full((1, 3), -1.0)
@@ -156,11 +157,11 @@ def point_transport(
 
     # Ensure electron hits pad plane and hits a non-beam pad
     if pad != -1 and pad not in BEAM_PADS_ARRAY:
-        point[0, 0] = pad
-        point[0, 1] = int(time)  # Convert from absolute time bucket to discretized
-        point[0, 2] = electrons
-
-    return point
+        tb = int(time)  # Convert from absolute time bucket to discretized
+        id = pair(tb, pad)
+        points[id] = (
+            points.get(id, 0) + electrons
+        )  # The get returns 0 if the key doesn't exist
 
 
 @njit
@@ -171,7 +172,8 @@ def transverse_transport(
     center: tuple[float, float],
     electrons: int,
     sigma_t: float,
-) -> np.ndarray:
+    points: dict[int, int],
+):
     """
     Transports all electrons created at a point in a simulated nucleus'
     track to the pad plane with transverse diffusion applied. This is done by
@@ -199,11 +201,9 @@ def transverse_transport(
     sigma_t: float
         Standard deviation of transverse diffusion at point
         being transported.
-
-    Returns
-    -------
-    numpy.ndarray
-        An Nx3 array representing the simplified point cloud
+    points: dict[int, int]
+        A dictionary mapping a unique pad,tb key to the number of electrons, which
+        will be filled by this function
     """
     mesh_centerx: float = center[0]
     mesh_centery: float = center[1]
@@ -217,23 +217,17 @@ def transverse_transport(
     step_sizey: float = 2 * 3 * sigma_t / (STEPS - 1)
     mesh = meshgrid(xsteps, ysteps)
 
-    # Point per mesh val
-    points = np.full((len(mesh), 3), -1.0)
-
-    # TODO needs testing
-    if len(points) == 0:
-        return points
-
-    for idx, pixel in enumerate(mesh):
+    for pixel in mesh:
         # Find pad number of hit pad, if it exists
         index_x, index_y = position_to_index(grid_edges, pixel)
         if index_x == -1 or index_y == -1:
             continue
-        pad: int = pad_grid[index_x, index_y]
+        pad: int = int(pad_grid[index_x, index_y])
 
         # Ensure electron hits pad plane and hits a non-beam pad
         if pad != -1 and pad not in BEAM_PADS_ARRAY:
-            points[idx, 0] = pad
+            tb = int(time)
+            id = pair(tb, pad)
             pixel_electrons = int(
                 (
                     bivariate_normal_pdf(pixel, center, sigma_t)
@@ -241,28 +235,9 @@ def transverse_transport(
                     * electrons
                 )
             )
-            points[idx, 1] = int(
-                time
-            )  # Convert from absolute time bucket to discretized
-            points[idx, 2] = pixel_electrons
-
-    points = points[points[:, 0] != -1.0]
-
-    if len(points) == 0:
-        return points
-
-    # Combine points that lie within the same pad for this time
-    unique_pads = np.unique(points[:, 0])
-    downsample = np.full((len(unique_pads), 3), -1.0)
-    for idx, pad in enumerate(unique_pads):
-        subpoints = points[points[:, 0] == pad]
-        downsample[idx, 0] = pad
-        downsample[idx, 1] = int(
-            time
-        )  # Convert from absolute time bucket to discretized
-        downsample[idx, 2] = subpoints[:, 2].sum()
-
-    return downsample
+            points[id] = (
+                points.get(id, 0) + pixel_electrons
+            )  # The get returns 0 if the key doesn't exist
 
 
 @njit
@@ -273,7 +248,8 @@ def find_pads_hit(
     center: tuple[float, float],
     electrons: int,
     sigma_t: float,
-) -> np.ndarray:
+    points: dict[int, int],
+):
     """
     Finds the pads hit by transporting the electrons created at a point in
     the nucleus' trajectory to the pad plane and applies transverse diffusion, if selected.
@@ -294,34 +270,25 @@ def find_pads_hit(
     sigma_t: float
         Standard deviation of transverse diffusion at point
         being transported.
-
-    Returns
-    -------
-    numpy.ndarray
-        An Nx3 array representing the simplified point cloud
+    points: dict[int, int]
+        A dictionary mapping a unique pad,tb key to the number of electrons, which
+        will be filled by this function
     """
     # Point transport
     if sigma_t == 0.0:
-        points: np.ndarray = point_transport(
-            pad_grid,
-            grid_edges,
-            time,
-            center,
-            electrons,
-        )
+        point_transport(pad_grid, grid_edges, time, center, electrons, points)
 
     # Transverse diffusion transport
     else:
-        points: np.ndarray = transverse_transport(
+        transverse_transport(
             pad_grid,
             grid_edges,
             time,
             center,
             electrons,
             sigma_t,
+            points,
         )
-
-    return points
 
 
 @njit
@@ -333,7 +300,7 @@ def transport_track(
     dv: float,
     track: np.ndarray,
     electrons: np.ndarray,
-):
+) -> np.ndarray:
     """
     High-level function that transports each point in a nucleus' trajectory
     to the pad plane, applying transverse diffusion if specified.
@@ -365,21 +332,23 @@ def transport_track(
         An Nx3 array representing the simplified point cloud
     """
 
-    points = np.empty((0, 3))
+    # Each point is a TB/pad combo in the TPC
+    points = Dict.empty(key_type=types.int64, value_type=types.int64)
     for idx, row in enumerate(track):
         time = row[2]
         center = (row[0], row[1])
         point_electrons = electrons[idx]
         sigma_t = np.sqrt(2.0 * diffusion * dv * time / efield)
-        new_points = find_pads_hit(
-            pad_grid,
-            grid_edges,
-            time,
-            center,
-            point_electrons,
-            sigma_t,
+        find_pads_hit(
+            pad_grid, grid_edges, time, center, point_electrons, sigma_t, points
         )
-        if len(new_points) > 0:
-            points = np.vstack((points, new_points))
 
-    return points
+    # Convert to numpy array of [pad, tb, e], now combined over pad/tb combos
+    point_array = np.empty((len(points), 3), dtype=float)
+    for idx, point in enumerate(points.items()):
+        tb, pad = unpair(point[0])
+        point_array[idx, 0] = pad
+        point_array[idx, 1] = tb
+        point_array[idx, 2] = point[1]
+
+    return point_array

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -149,10 +149,9 @@ def point_transport(
         will be filled by this function
     """
     # Find pad number of hit pad, if it exists
-    point = np.full((1, 3), -1.0)
     index_x, index_y = position_to_index(grid_edges, center)
     if index_x == -1 or index_y == -1:
-        return point
+        return
     pad = pad_grid[index_x, index_y]
 
     # Ensure electron hits pad plane and hits a non-beam pad

--- a/src/attpc_engine/detector/writer.py
+++ b/src/attpc_engine/detector/writer.py
@@ -123,7 +123,10 @@ class SpyralWriter:
     config: Config
         The simulation configuration.
     max_file_size: int
-        The maximum file size of a point cloud file in bytes. Defualt value is 10 Gb.
+        The maximum file size of a point cloud file in bytes. Defualt value is 1 Gb.
+    first_run_number: int
+        The starting run number. You can use this to change the starting point for run files
+        (i.e. run_0000 or run_0008) to avoid overwritting previous results. Default is 0
 
     Attributes
     ----------
@@ -155,12 +158,16 @@ class SpyralWriter:
     """
 
     def __init__(
-        self, directory_path: Path, config: Config, max_file_size: int = int(5e9)
+        self,
+        directory_path: Path,
+        config: Config,
+        max_file_size: int = 1_000_000_000,
+        first_run_number=0,
     ):
         self.directory_path: Path = directory_path
         self.response: np.ndarray = get_response(config).copy()
         self.max_file_size: int = max_file_size
-        self.run_number = 0
+        self.run_number = first_run_number
         self.event_number_low = 0  # Kinematics generator always starts with event 0
         self.event_number_high = 0  # By default set to 0
         self.create_file()

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -29,7 +29,7 @@ electronics = ElectronicsParams(
     shaping_time=1000,
     micromegas_edge=10,
     windows_edge=560,
-    adc_threshold=40.0,
+    adc_threshold=40,
 )
 
 pads = PadParams()

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,0 +1,26 @@
+from attpc_engine.detector.pairing import pair, unpair
+
+
+def test_pairing_low():
+    x = 56
+    y = 937
+    id = y**2 + x
+    id_u = pair(x, y)
+    x_u, y_u = unpair(id_u)
+    print(id, x_u, y_u)
+
+    assert id_u == id
+    assert x_u == x
+    assert y_u == y
+
+
+def test_pairing_hi():
+    x = 937
+    y = 56
+    id = x**2 + x + y
+    id_u = pair(x, y)
+    x_u, y_u = unpair(id_u)
+
+    assert id_u == id
+    assert x_u == x
+    assert y_u == y


### PR DESCRIPTION
Previously transport did not properly integrate the charge if two hits occurred at the same time bucket in the same pad. Result was that in some cases far too many points would be written out with too diffuse of charge. 

Fix: use a dictionary keyed by the paired TB & pad ID to sum the charge within pads.

Currently, this only fixes the issue on a per track basis. To be completely accurate this summing should occur over all trajectories.

WIP