### PR TITLE
Add multiple track hits together

### DIFF
--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -115,7 +115,9 @@ class SimEvent:
         point_array[:, 1] += rng.uniform(low=0.0, high=1.0, size=len(point_array))
 
         # Remove points outside legal bounds in time. TODO check if this is needed
-        point_array = point_array[point_array[:, 1] < NUM_TB]
+        point_array = point_array[
+            np.logical_and(0 <= point_array[:, 1], point_array[:, 1] < NUM_TB)
+        ]
 
         return point_array
 

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -123,7 +123,7 @@ class SimEvent:
 
 
 @njit
-def dict_to_points(points: numba.typed.Dict[int, int]) -> np.ndarray:
+def dict_to_points(points: numba.typed.Dict[int, int]) -> np.ndarray:  # type: ignore
     """
     Converts dictionary of N pad,tb keys with corresponding number of electrons
     to Nx3 array where each row is [pad, tb, e], now combined over pad/tb combos.
@@ -295,7 +295,7 @@ class SimParticle:
 
     def generate_point_cloud(
         self, config: Config, rng: Generator, points: numba.typed.Dict[int, int]
-    ):
+    ):  # type: ignore
         """Create the point cloud
 
         Finds the pads hit by the electrons transported from each point

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -123,7 +123,7 @@ class SimEvent:
 
 
 @njit
-def dict_to_points(points: numba.typed.Dict[int, int]) -> np.ndarray:  # type: ignore
+def dict_to_points(points: Dict[int, int]) -> np.ndarray:
     """
     Converts dictionary of N pad,tb keys with corresponding number of electrons
     to Nx3 array where each row is [pad, tb, e], now combined over pad/tb combos.
@@ -294,8 +294,8 @@ class SimParticle:
         return electrons
 
     def generate_point_cloud(
-        self, config: Config, rng: Generator, points: numba.typed.Dict[int, int]
-    ):  # type: ignore
+        self, config: Config, rng: Generator, points: Dict[int, int]
+    ):
         """Create the point cloud
 
         Finds the pads hit by the electrons transported from each point

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -123,7 +123,7 @@ class SimEvent:
 
 
 @njit
-def dict_to_points(points: Dict):
+def dict_to_points(points: numba.typed.Dict[int, int]) -> np.ndarray:
     """
     Converts dictionary of N pad,tb keys with corresponding number of electrons
     to Nx3 array where each row is [pad, tb, e], now combined over pad/tb combos.
@@ -294,8 +294,8 @@ class SimParticle:
         return electrons
 
     def generate_point_cloud(
-        self, config: Config, rng: Generator, points
-    ) -> np.ndarray:
+        self, config: Config, rng: Generator, points: numba.typed.Dict[int, int]
+    ):
         """Create the point cloud
 
         Finds the pads hit by the electrons transported from each point
@@ -307,11 +307,6 @@ class SimParticle:
             The simulation configuration
         rng: numpy.random.Generator
             numpy random number generator
-        points: numba.typed.Dict[int, int]
-            A dictionary mapping a unique pad,tb key to the number of electrons.
-
-        Returns
-        -------
         points: numba.typed.Dict[int, int]
             A dictionary mapping a unique pad,tb key to the number of electrons.
         """
@@ -346,8 +341,6 @@ class SimParticle:
             electrons,
             points,
         )
-
-        return points
 
 
 def run_simulation(

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -10,6 +10,7 @@ from .transporter import transport_track
 from .writer import SimulationWriter
 from .constants import NUM_TB
 from .. import nuclear_map
+from .pairing import unpair
 
 import numpy as np
 import h5py as h5
@@ -17,6 +18,10 @@ from tqdm import trange
 from scipy.integrate import solve_ivp
 from numpy.random import default_rng, Generator
 from pathlib import Path
+from numba.typed import Dict
+from numba.core import types
+from numba import njit
+
 
 # Time steps to solve ODE at. Each step is 1e-10 s
 TIME_STEPS = np.linspace(0, 10e-7, 10001)
@@ -93,20 +98,52 @@ class SimEvent:
 
         Returns
         -------
-        numpy.ndarray
+        point_array: numpy.ndarray
             An Nx3 array representing the point cloud. Each row is a point, with elements
             [pad id, time bucket, electrons]
         """
         # Sum points from all particles
-        points: np.ndarray = np.empty((0, 3))
+        points = Dict.empty(key_type=types.int64, value_type=types.int64)
         for nuc in self.nuclei:
-            new_points = nuc.generate_point_cloud(config, rng)
-            points = np.vstack((points, new_points))
+            nuc.generate_point_cloud(config, rng, points)
+
+        # Convert to numpy array of [pad, tb, e], now combined over pad/tb combos
+        point_array = dict_to_points(points)
+
+        # Wiggle point TBs over interval [0.0, 1.0). This simulates effect of converting
+        # the (in principle) int TBs to floats.
+        point_array[:, 1] += rng.uniform(low=0.0, high=1.0, size=len(point_array))
 
         # Remove points outside legal bounds in time. TODO check if this is needed
-        points = points[points[:, 1] < NUM_TB]
+        point_array = point_array[point_array[:, 1] < NUM_TB]
 
-        return points
+        return point_array
+
+
+@njit
+def dict_to_points(points: Dict):
+    """
+    Converts dictionary of N pad,tb keys with corresponding number of electrons
+    to Nx3 array where each row is [pad, tb, e], now combined over pad/tb combos.
+
+    Parameters
+    ----------
+    points: numba.typed.Dict[int, int]
+        A dictionary mapping a unique pad,tb key to the number of electrons.
+
+    Returns
+    -------
+    point_array: numpy.ndarray
+        Array of points.
+    """
+    point_array = np.empty((len(points), 3), dtype=float)
+    for idx, point in enumerate(points.items()):
+        tb, pad = unpair(point[0])
+        point_array[idx, 0] = pad
+        point_array[idx, 1] = tb
+        point_array[idx, 2] = point[1]
+
+    return point_array
 
 
 class SimParticle:
@@ -254,7 +291,9 @@ class SimParticle:
         )
         return electrons
 
-    def generate_point_cloud(self, config: Config, rng: Generator) -> np.ndarray:
+    def generate_point_cloud(
+        self, config: Config, rng: Generator, points
+    ) -> np.ndarray:
         """Create the point cloud
 
         Finds the pads hit by the electrons transported from each point
@@ -264,11 +303,15 @@ class SimParticle:
         ----------
         config: Config
             The simulation configuration
+        rng: numpy.random.Generator
+            numpy random number generator
+        points: numba.typed.Dict[int, int]
+            A dictionary mapping a unique pad,tb key to the number of electrons.
 
         Returns
         -------
-        numpy.ndarray
-            Array of points (point cloud)
+        points: numba.typed.Dict[int, int]
+            A dictionary mapping a unique pad,tb key to the number of electrons.
         """
         # Generate nucleus' track and calculate the electrons made at each point
         track = self.generate_track(config)
@@ -299,11 +342,9 @@ class SimParticle:
             config.drift_velocity,
             track,
             electrons,
+            points,
         )
 
-        # Wiggle point TBs over interval [0.0, 1.0). This simulates effect of converting
-        # the (in principle) int TBs to floats.
-        points[:, 1] += rng.uniform(low=0.0, high=1.0, size=len(points))
         return points
 
 

--- a/src/attpc_engine/detector/solver.py
+++ b/src/attpc_engine/detector/solver.py
@@ -90,9 +90,9 @@ def stop_condition(
         time step, unused
     state: ndarray
         the state of the particle (x,y,z,vx,vy,vz)
-    Bfield: float
+    bfield: float
         the magnitude of the magnetic field, unused
-    Efield: float
+    efield: float
         the magnitude of the electric field, unused
     target: Target
         the material through which the particle travels, unused
@@ -134,9 +134,9 @@ def forward_z_bound_condition(
         time step, unused
     state: ndarray
         the state of the particle (x,y,z,vx,vy,vz)
-    Bfield: float
+    bfield: float
         the magnitude of the magnetic field, unused
-    Efield: float
+    efield: float
         the magnitude of the electric field, unused
     target: Target
         the material through which the particle travels, unused
@@ -174,9 +174,9 @@ def backward_z_bound_condition(
         time step, unused
     state: ndarray
         the state of the particle (x,y,z,vx,vy,vz)
-    Bfield: float
+    bfield: float
         the magnitude of the magnetic field, unused
-    Efield: float
+    efield: float
         the magnitude of the electric field, unused
     target: Target
         the material through which the particle travels, unused
@@ -214,9 +214,9 @@ def rho_bound_condition(
         time step, unused
     state: ndarray
         the state of the particle (x,y,z,vx,vy,vz)
-    Bfield: float
+    bfield: float
         the magnitude of the magnetic field, unused
-    Efield: float
+    efield: float
         the magnitude of the electric field, unused
     target: Target
         the material through which the particle travels, unused

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -298,8 +298,8 @@ def transport_track(
     dv: float,
     track: np.ndarray,
     electrons: np.ndarray,
-    points: Dict,
-) -> np.ndarray:
+    points: numba.typed.Dict[int, int],
+):
     """
     High-level function that transports each point in a nucleus' trajectory
     to the pad plane, applying transverse diffusion if specified.
@@ -326,11 +326,6 @@ def transport_track(
         1xN array of electrons created each time step (point) of the trajectory.
     points: numba.typed.Dict
         A dictionary mapping a unique pad,tb key to the number of electrons.
-
-    Returns
-    -------
-    points: numba.typed.Dict[int, int]
-        A dictionary mapping a unique pad,tb key to the number of electrons.
     """
 
     # Each point is a TB/pad combo in the TPC
@@ -342,5 +337,3 @@ def transport_track(
         find_pads_hit(
             pad_grid, grid_edges, time, center, point_electrons, sigma_t, points
         )
-
-    return points

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -299,7 +299,7 @@ def transport_track(
     track: np.ndarray,
     electrons: np.ndarray,
     points: numba.typed.Dict[int, int],
-):
+):  # type: ignore
     """
     High-level function that transports each point in a nucleus' trajectory
     to the pad plane, applying transverse diffusion if specified.

--- a/src/attpc_engine/detector/transporter.py
+++ b/src/attpc_engine/detector/transporter.py
@@ -124,7 +124,7 @@ def point_transport(
     time: float,
     center: tuple[float, float],
     electrons: int,
-    points: dict[int, int],
+    points: Dict[int, int],
 ):
     """
     Transports all electrons created at a point in a simulated nucleus' track
@@ -170,7 +170,7 @@ def transverse_transport(
     center: tuple[float, float],
     electrons: int,
     sigma_t: float,
-    points: dict[int, int],
+    points: Dict[int, int],
 ):
     """
     Transports all electrons created at a point in a simulated nucleus'
@@ -246,7 +246,7 @@ def find_pads_hit(
     center: tuple[float, float],
     electrons: int,
     sigma_t: float,
-    points: dict[int, int],
+    points: Dict[int, int],
 ):
     """
     Finds the pads hit by transporting the electrons created at a point in
@@ -298,8 +298,8 @@ def transport_track(
     dv: float,
     track: np.ndarray,
     electrons: np.ndarray,
-    points: numba.typed.Dict[int, int],
-):  # type: ignore
+    points: Dict[int, int],
+):
     """
     High-level function that transports each point in a nucleus' trajectory
     to the pad plane, applying transverse diffusion if specified.
@@ -324,7 +324,7 @@ def transport_track(
         the Nth time step.
     electrons: np.ndarray
         1xN array of electrons created each time step (point) of the trajectory.
-    points: numba.typed.Dict
+    points: numba.typed.Dict[int, int]
         A dictionary mapping a unique pad,tb key to the number of electrons.
     """
 


### PR DESCRIPTION
Points from all tracks are now recorded using the same dictionary and converted into an array after the fact. This solves the edge case of recording multiple points for multiple tracks hitting the same pad at the same time. Also fixed some documentation stuff. From some very preliminary testing, there seems to be a speed up of around 25% using one dictionary and then converting only once.