### PR TITLE
Chunkify kinematics data

### DIFF
--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -395,7 +395,9 @@ def run_simulation(
 
     for event_number in trange(n_events, miniters=miniters):  # type: ignore
         chunk = event_number // chunk_size  # integer floor division
-        dataset: h5.Dataset = input_data_group[f"chunk_{chunk}"][f"event_{event_number}"]  # type: ignore
+        dataset: h5.Dataset = input_data_group[f"chunk_{chunk}"][  # type: ignore
+            f"event_{event_number}"
+        ]  # type: ignore
         sim = SimEvent(
             dataset[:].copy(),  # type: ignore
             np.array(

--- a/src/attpc_engine/detector/simulator.py
+++ b/src/attpc_engine/detector/simulator.py
@@ -366,12 +366,17 @@ def run_simulation(
     print("------- AT-TPC Simulation Engine -------")
     print(f"Applying detector effects to kinematics from file: {input_path}")
     input = h5.File(input_path, "r")
-    input_data_group = input["data"]
+    input_data_group: h5.Group = input["data"]  # type: ignore
     proton_numbers = input_data_group.attrs["proton_numbers"]
     mass_numbers = input_data_group.attrs["mass_numbers"]
 
     n_events: int = input_data_group.attrs["n_events"]  # type: ignore
-    print(f"Found {n_events} kinematics events.")
+    miniters = 0.01 * n_events
+    n_chunks: int = input_data_group.attrs["n_chunks"]  # type: ignore
+    chunk_size: int = input_data_group.attrs["chunk_size"]  # type: ignore
+    print(
+        f"Found {n_events} kinematics events in {n_chunks} {chunk_size} event chunks."
+    )
     print(f"Output will be written to {writer.get_directory_name()}.")
 
     rng = default_rng()
@@ -388,8 +393,9 @@ def run_simulation(
         """
     )
 
-    for event_number in trange(n_events):  # type: ignore
-        dataset: h5.Dataset = input_data_group[f"event_{event_number}"]  # type: ignore
+    for event_number in trange(n_events, miniters=miniters):  # type: ignore
+        chunk = event_number // chunk_size  # integer floor division
+        dataset: h5.Dataset = input_data_group[f"chunk_{chunk}"][f"event_{event_number}"]  # type: ignore
         sim = SimEvent(
             dataset[:].copy(),  # type: ignore
             np.array(

--- a/src/attpc_engine/kinematics/convert_kinematics.py
+++ b/src/attpc_engine/kinematics/convert_kinematics.py
@@ -18,6 +18,7 @@ def convert_kinematics_hdf5_to_polars(input_path: Path, output_path: Path) -> No
     proton_numbers: np.ndarray = input_data_group.attrs["proton_numbers"]  # type: ignore
     mass_numbers: np.ndarray = input_data_group.attrs["mass_numbers"]  # type: ignore
     n_events: int = input_data_group.attrs["n_events"]  # type: ignore
+    chunk_size: int = input_data_group.attrs["chunk_size"]  # type: ignore
     n_nuclei = len(proton_numbers)
     nuclei = [
         nuclear_map.get_data(proton_numbers[idx], mass_numbers[idx])  # type: ignore
@@ -40,7 +41,8 @@ def convert_kinematics_hdf5_to_polars(input_path: Path, output_path: Path) -> No
     }
 
     for event in trange(n_events):
-        dataset: h5.Dataset = input_data_group[f"event_{event}"]  # type: ignore
+        chunk = event // chunk_size  # integer floor division
+        dataset: h5.Dataset = input_data_group[f"chunk_{chunk}"][f"event_{event_number}"]  # type: ignore
         vx = dataset.attrs["vertex_x"]
         vy = dataset.attrs["vertex_y"]
         vz = dataset.attrs["vertex_z"]

--- a/src/attpc_engine/kinematics/convert_kinematics.py
+++ b/src/attpc_engine/kinematics/convert_kinematics.py
@@ -42,7 +42,7 @@ def convert_kinematics_hdf5_to_polars(input_path: Path, output_path: Path) -> No
 
     for event in trange(n_events):
         chunk = event // chunk_size  # integer floor division
-        dataset: h5.Dataset = input_data_group[f"chunk_{chunk}"][f"event_{event_number}"]  # type: ignore
+        dataset: h5.Dataset = input_data_group[f"chunk_{chunk}"][f"event_{event}"]  # type: ignore
         vx = dataset.attrs["vertex_x"]
         vy = dataset.attrs["vertex_y"]
         vz = dataset.attrs["vertex_z"]


### PR DESCRIPTION
Divide kinematics data into chunks to avoid key-related performance issues outlined in #40 

Updated detector and converter reading to accommodate these changes. No performance lost that I could detect on the read.

Right now chunks are hardcoded to 1_000_000 events. Maybe could be input config later.

Change progress bars to only update every 1%. Save some small amount of performance.